### PR TITLE
Moving lpips vgg download to `.cache` folder

### DIFF
--- a/taming/modules/losses/lpips.py
+++ b/taming/modules/losses/lpips.py
@@ -1,5 +1,6 @@
 """Stripped version of https://github.com/richzhang/PerceptualSimilarity/tree/master/models"""
 
+import os
 import torch
 import torch.nn as nn
 from torchvision import models
@@ -25,7 +26,7 @@ class LPIPS(nn.Module):
             param.requires_grad = False
 
     def load_from_pretrained(self, name="vgg_lpips"):
-        ckpt = get_ckpt_path(name, "taming/modules/autoencoder/lpips")
+        ckpt = get_ckpt_path(name, os.path.expanduser("~/.cache/taming/modules/autoencoder/lpips"))
         self.load_state_dict(torch.load(ckpt, map_location=torch.device("cpu")), strict=False)
         print("loaded pretrained LPIPS loss from {}".format(ckpt))
 


### PR DESCRIPTION
Using the installed `taming` module from other folders causes the `LPIPS VGG` weights to be downloaded again. This causes unnecessary model replication. Saving the weights to cache folder prevents this and is accepted practice for libraries like torch.

## Testing

Local testing to run basic VQGAN training.