### PR TITLE
Import Literal from typing_extensions if from typing fails

### DIFF
--- a/taming/data/helper_types.py
+++ b/taming/data/helper_types.py
@@ -1,7 +1,11 @@
-from typing import Dict, Tuple, Literal, Optional, NamedTuple, Union
-
+from typing import Dict, Tuple, Optional, NamedTuple, Union
 from PIL.Image import Image as pil_image
 from torch import Tensor
+
+try:
+  from typing import Literal
+except ImportError:
+  from typing_extensions import Literal
 
 Image = Union[Tensor, pil_image]
 BoundingBox = Tuple[float, float, float, float]  # x0, y0, w, h


### PR DESCRIPTION
Fixes the issue of Google Colab failing at importing `Literal` from `typing` instead of `typing_extensions`. Please assess.

---

You can observe the problem in your own demo notebook: https://colab.research.google.com/github/CompVis/taming-transformers/blob/master/scripts/taming-transformers.ipynb

![image](https://user-images.githubusercontent.com/50331907/136427543-69381f2e-2dda-44be-aa2f-a6118f8d6f5c.png)

