### PR TITLE
Update helper_types.py

### DIFF
--- a/taming/data/helper_types.py
+++ b/taming/data/helper_types.py
@@ -1,4 +1,5 @@
-from typing import Dict, Tuple, Literal, Optional, NamedTuple, Union
+from typing import Dict, Tuple, Optional, NamedTuple, Union
+from typing_extensions import Literal
 
 from PIL.Image import Image as pil_image
 from torch import Tensor


### PR DESCRIPTION
This makes the code backwards compatible with Python 3.7, which is used on Google colab.