### PR TITLE
fix get_image_size

### DIFF
--- a/taming/data/image_transforms.py
+++ b/taming/data/image_transforms.py
@@ -5,7 +5,7 @@ from typing import Union
 import torch
 from torch import Tensor
 from torchvision.transforms import RandomCrop, functional as F, CenterCrop, RandomHorizontalFlip, PILToTensor
-from torchvision.transforms.functional import _get_image_size as get_image_size
+from torchvision.transforms.functional import get_image_size as get_image_size
 
 from taming.data.helper_types import BoundingBox, Image
 


### PR DESCRIPTION
This [example](https://github.com/CompVis/taming-transformers#sampling) throws this error "ImportError: cannot import name '_get_image_size' from 'torchvision.transforms.functional'"

Related to [this](https://github.com/pytorch/vision/issues/4328) 

Fixed by this PR. 