### PR TITLE
Allow folders for the train and validation paths.

### DIFF
--- a/taming/data/custom.py
+++ b/taming/data/custom.py
@@ -23,16 +23,46 @@ class CustomBase(Dataset):
 class CustomTrain(CustomBase):
     def __init__(self, size, training_images_list_file):
         super().__init__()
-        with open(training_images_list_file, "r") as f:
-            paths = f.read().splitlines()
+        
+        isFile = os.path.isfile(training_images_list_file)
+        isDirectory = os.path.isdir(training_images_list_file)
+        
+        if isFile:
+           with open(training_images_list_file, "r") as f:
+               paths = f.read().splitlines()            
+       
+        if isDirectory:
+           paths = []
+           for images in os.listdir(training_images_list_file):
+           
+               # check if the image ends with png or jpg or jpeg
+               if (images.endswith(".png") or images.endswith(".jpg")\
+                   or images.endswith(".jpeg")):
+                   paths.append(os.path.join(training_images_list_file, images))
+                   
         self.data = ImagePaths(paths=paths, size=size, random_crop=False)
 
 
 class CustomTest(CustomBase):
     def __init__(self, size, test_images_list_file):
         super().__init__()
-        with open(test_images_list_file, "r") as f:
-            paths = f.read().splitlines()
+        
+        isFile = os.path.isfile(test_images_list_file)
+        isDirectory = os.path.isdir(test_images_list_file)
+        
+        if isFile:
+            with open(test_images_list_file, "r") as f:
+                paths = f.read().splitlines()            
+                
+        if isDirectory:
+            paths = []
+            for images in os.listdir(test_images_list_file):
+                
+                # check if the image ends with png or jpg or jpeg
+                if (images.endswith(".png") or images.endswith(".jpg")\
+                    or images.endswith(".jpeg")):
+                    paths.append(os.path.join(test_images_list_file, images))
+        
         self.data = ImagePaths(paths=paths, size=size, random_crop=False)
 
 


### PR DESCRIPTION
This changes in the `taming/data/custom.py` file allow the use of folders for the training and validation paths while been compatible with how it was used before. This should make it easier to train on custom data as you no longer need to create a `train.txt` and `val.txt` file manually which sometimes can be a time-consuming and tedious task, now you can just create two folders, one for the train and one for the validation containing the images inside and the script will discover the files and create the list of paths by itself, this can also allow you to add more images to those folders later without having to manually recreate the train and validation files, not sure about the use for that but the option is there.