### PR TITLE
Remove reference to deprecated feature

### DIFF
--- a/taming/data/utils.py
+++ b/taming/data/utils.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import numpy as np
 import torch
 from taming.data.helper_types import Annotation
-from torch._six import string_classes
 from torch.utils.data._utils.collate import np_str_obj_array_pattern, default_collate_err_msg_format
 from tqdm import tqdm
 
@@ -149,7 +148,7 @@ def custom_collate(batch):
         return torch.tensor(batch, dtype=torch.float64)
     elif isinstance(elem, int):
         return torch.tensor(batch)
-    elif isinstance(elem, string_classes):
+    elif isinstance(elem, (str, bytes)):
         return batch
     elif isinstance(elem, collections.abc.Mapping):
         return {key: custom_collate([d[key] for d in batch]) for key in elem}


### PR DESCRIPTION
**torch._six** has been deprecated, and this reference causes the code to not run. I removed the import and replaced the string_classes comparison with what **string_classes** actually was / is.