### PR TITLE
torch._six is depreciated, remove import

### DIFF
--- a/taming/data/utils.py
+++ b/taming/data/utils.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import numpy as np
 import torch
 from taming.data.helper_types import Annotation
-from torch._six import string_classes
 from torch.utils.data._utils.collate import np_str_obj_array_pattern, default_collate_err_msg_format
 from tqdm import tqdm
 
@@ -149,7 +148,7 @@ def custom_collate(batch):
         return torch.tensor(batch, dtype=torch.float64)
     elif isinstance(elem, int):
         return torch.tensor(batch)
-    elif isinstance(elem, string_classes):
+    elif isinstance(elem, str):
         return batch
     elif isinstance(elem, collections.abc.Mapping):
         return {key: custom_collate([d[key] for d in batch]) for key in elem}


### PR DESCRIPTION
Torch does not support torch._six anymore, so removed from torch._six import string_classes

Replaced string_classes with str.

Reference: https://github.com/pytorch/pytorch/pull/94709