### PR TITLE
Drop nonexisting module torch._six

### DIFF
--- a/taming/data/utils.py
+++ b/taming/data/utils.py
@@ -8,10 +8,10 @@ from pathlib import Path
 import numpy as np
 import torch
 from taming.data.helper_types import Annotation
-from torch._six import string_classes
 from torch.utils.data._utils.collate import np_str_obj_array_pattern, default_collate_err_msg_format
 from tqdm import tqdm
 
+string_classes = str
 
 def unpack(path):
     if path.endswith("tar.gz"):


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'torch._six'`.

`torch._six` is obsolete.